### PR TITLE
commonjs-module-option switch to commonjs so the library can work in react native

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "moduleResolution": "node",
-    "module": "umd",
+    "module": "CommonJS",
     "noEmitHelpers": false,
     "skipLibCheck": true,
     "lib": ["es2015"],


### PR DESCRIPTION
UMD modules make the metro bundler sad.  We need to switch to commonjs
